### PR TITLE
fix(runtime/module): 🐛  Use a native `Error` instead of custom `RuntimeError`

### DIFF
--- a/.changeset/rotten-dryers-promise.md
+++ b/.changeset/rotten-dryers-promise.md
@@ -1,0 +1,5 @@
+---
+"@terminal-nerds/snippets-runtime": minor
+---
+
+Use native `Error` instead of custom `RuntimeError`

--- a/packages/array/source/schema/empty/empty.ts
+++ b/packages/array/source/schema/empty/empty.ts
@@ -1,4 +1,4 @@
-import { ARRAY_SCHEMA, validateArray } from "../schema.ts";
+import { ARRAY_SCHEMA, validateArray } from "../native/native.ts";
 
 export const EMPTY_ARRAY_SCHEMA = ARRAY_SCHEMA.length(0);
 

--- a/packages/array/source/schema/native/native.test.ts
+++ b/packages/array/source/schema/native/native.test.ts
@@ -3,7 +3,7 @@ import { returns, throws } from "@terminal-nerds/snippets-test/unit";
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
 
-import { validateArray } from "./schema.ts";
+import { validateArray } from "./native.ts";
 
 describe("validateArray(value)", () => {
 	it(throws(ZodError).on(`non-array values`).samples(SAMPLE_PRIMITIVES), () => {

--- a/packages/array/source/schema/native/native.ts
+++ b/packages/array/source/schema/native/native.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const ARRAY_SCHEMA = z.array(z.any());
+
+export type AnyArray = ReadonlyArray<unknown>;
+
+export function validateArray(value: unknown): asserts value is AnyArray {
+	ARRAY_SCHEMA.parse(value);
+}
+
+export function validateArrays(...arrays: AnyArray[]): void {
+	for (const currentArray of arrays) {
+		validateArray(currentArray);
+	}
+}

--- a/packages/array/source/schema/schema.ts
+++ b/packages/array/source/schema/schema.ts
@@ -1,20 +1,5 @@
-import { z } from "zod";
-
-export const ARRAY_SCHEMA = z.array(z.any());
-
-export type AnyArray = ReadonlyArray<unknown>;
-
-export function validateArray(value: unknown): asserts value is AnyArray {
-	ARRAY_SCHEMA.parse(value);
-}
-
-export function validateArrays(...arrays: AnyArray[]): void {
-	for (const currentArray of arrays) {
-		validateArray(currentArray);
-	}
-}
-
 export * from "./bigint/bigint.ts";
 export * from "./empty/empty.ts";
 export * from "./float/float.ts";
 export * from "./integer/integer.ts";
+export * from "./native/native.ts";

--- a/packages/runtime/source/module/module.ts
+++ b/packages/runtime/source/module/module.ts
@@ -1,16 +1,21 @@
-import { RuntimeError } from "@terminal-nerds/snippets-error/custom";
+/* import { RuntimeError } from "@terminal-nerds/snippets-error/custom"; */
 import { resolveModule } from "local-pkg";
 
 import { IN_BROWSER } from "../environment/environment.ts";
 
-/** @see {@link https://nodejs.org/api/modules.html#modules-commonjs-modules} CommonJS Module */
+/**
+ * @see {@link https://nodejs.org/api/modules.html#modules-commonjs-modules} CommonJS Module
+ */
 export const IN_CJS = typeof globalThis.require === "function";
 
-/** @see {@link https://nodejs.org/api/esm.html#modules-ecmascript-modules} ECMAScript Module */
+/**
+ * @see {@link https://nodejs.org/api/esm.html#modules-ecmascript-modules} ECMAScript Module
+ */
 export const IN_ESM = !IN_CJS && Boolean(import.meta);
 
 export function hasModule(name: string): boolean {
-	if (IN_BROWSER) throw new RuntimeError(`You cannot check for module existence in the browser.`);
+	/* if (IN_BROWSER) throw new RuntimeError(`You cannot check for module existence in the browser.`); */
+	if (IN_BROWSER) throw new Error(`You cannot check for module existence in the browser.`);
 
 	return Boolean(resolveModule(name));
 }


### PR DESCRIPTION
# What is the purpose of this Pull Request?

See [Changesets](./90/files?file-filters%5B%5D=.md&show-viewed-files=true) for details.

Temporary workaround for issues with CJS from `modern-error`

<!-- If not, delete the above line. -->

## Type of this Pull Request

<!-- -   ✨ Implementing a new feature -->
-   🐛 Bug fix
<!-- -   📝 Documentation changes -->
<!-- -   ⚙️ Workflow adjustments -->
<!-- -   🔧 Configurations tweaks -->
<!-- -   ♻️  Code refactoring -->
<!-- -   ⚡ Performance improvements -->
<!-- -   🧪 Test updates -->
<!-- -   Other: ... -->
